### PR TITLE
Update Lambda Runtime to Python 3.9 in CloudFormation Stack

### DIFF
--- a/deployment/cloud_formation/cfn_lambda.yaml
+++ b/deployment/cloud_formation/cfn_lambda.yaml
@@ -1,37 +1,37 @@
-AWSTemplateFormatVersion: "2010-09-09"
-Description: "CloudFormation template to create a lambda function."
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'CloudFormation template to create a lambda function.'
 
 Parameters:
     LambdaName:
         Type: String
         Description: Lambda function name
-        Default: "activity-detection-lambda"
+        Default: 'activity-detection-lambda'
 
     LambdaCodeBucket:
         Type: String
         Description: "Lambda SourceCode bucket name."
-        Default: "activity-detection-data-bucket"
+        Default: 'activity-detection-data-bucket'
 
     TriggerBucketName:
         Type: String
         Description: "S3 bucket name used to create a trigger."
-        Default: "activity-detection-livestream-bucket"
-
-    DetectionTableName:
+        Default: 'activity-detection-livestream-bucket'
+        
+    DetectionTableName: 
         Type: String
         Description: DynamoDB table to save prediction results
         Default: "activity-detection-table"
 
-    EndpointName:
+    EndpointName: 
         Type: String
         Description: SageMaker endpoint for model deployment
         Default: "activity-detection-endpoint"
 
-    ModelMaxFrames:
+    ModelMaxFrames: 
         Type: Number
         Description: Maximum number of frames used for activity detection model
         Default: 32
-
+        
 Resources:
     LivestreamLambdaFunction:
         Type: AWS::Lambda::Function
@@ -39,7 +39,7 @@ Resources:
             FunctionName: !Ref LambdaName
             Runtime: python3.9
             Role: !GetAtt LivestreamLambdaRole.Arn
-            Code:
+            Code: 
                 S3Bucket: !Ref LambdaCodeBucket
                 S3Key: "artifacts/amazon-sagemaker-activity-detection/deployment/lambda/lambda_function.zip"
             Handler: lambda_function.lambda_handler
@@ -57,41 +57,41 @@ Resources:
             Action: lambda:InvokeFunction
             FunctionName: !Ref LivestreamLambdaFunction
             Principal: s3.amazonaws.com
-            SourceArn:
+            SourceArn: 
                 Fn::Sub: "arn:aws:s3:::${TriggerBucketName}"
             SourceAccount: !Ref AWS::AccountId
-
+            
     LambdaTrigger:
-        Type: AWS::S3::Bucket
-        DependsOn: LivestreamLambdaPermission
-        Properties:
-            BucketName: !Ref TriggerBucketName
-            NotificationConfiguration:
-                LambdaConfigurations:
-                    - Event: s3:ObjectCreated:*
-                      Filter:
-                          S3Key:
-                              Rules:
-                                  - Name: prefix
-                                    Value: "livestream_pipe/"
-                                  - Name: suffix
-                                    Value: ".ts"
-                      Function: !GetAtt LivestreamLambdaFunction.Arn
-
+       Type: AWS::S3::Bucket
+       DependsOn: LivestreamLambdaPermission
+       Properties:
+           BucketName: !Ref TriggerBucketName
+           NotificationConfiguration:
+               LambdaConfigurations:
+                   - Event: s3:ObjectCreated:*
+                     Filter:
+                       S3Key:
+                           Rules:
+                               - Name: prefix
+                                 Value: "livestream_pipe/"
+                               - Name: suffix
+                                 Value: ".ts"
+                     Function: !GetAtt LivestreamLambdaFunction.Arn
+                     
     LivestreamLambdaRole:
-        Type: "AWS::IAM::Role"
+        Type: 'AWS::IAM::Role'
         Properties:
-            RoleName: "LivestreamLambdaRole"
+            RoleName: 'LivestreamLambdaRole'
             AssumeRolePolicyDocument:
                 Version: 2012-10-17
                 Statement:
-                    - Effect: Allow
-                      Principal:
-                          Service:
-                              - "lambda.amazonaws.com"
-                      Action:
-                          - "sts:AssumeRole"
+                  - Effect: Allow
+                    Principal:
+                      Service:
+                      - "lambda.amazonaws.com"
+                    Action:
+                      - 'sts:AssumeRole'
             ManagedPolicyArns:
-                - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-                - "arn:aws:iam::aws:policy/AmazonS3FullAccess"
-                - "arn:aws:iam::aws:policy/AmazonSageMakerFullAccess"
+                - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+                - 'arn:aws:iam::aws:policy/AmazonS3FullAccess'
+                - 'arn:aws:iam::aws:policy/AmazonSageMakerFullAccess'

--- a/deployment/cloud_formation/cfn_lambda.yaml
+++ b/deployment/cloud_formation/cfn_lambda.yaml
@@ -1,45 +1,45 @@
-AWSTemplateFormatVersion: '2010-09-09'
-Description: 'CloudFormation template to create a lambda function.'
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "CloudFormation template to create a lambda function."
 
 Parameters:
     LambdaName:
         Type: String
         Description: Lambda function name
-        Default: 'activity-detection-lambda'
+        Default: "activity-detection-lambda"
 
     LambdaCodeBucket:
         Type: String
         Description: "Lambda SourceCode bucket name."
-        Default: 'activity-detection-data-bucket'
+        Default: "activity-detection-data-bucket"
 
     TriggerBucketName:
         Type: String
         Description: "S3 bucket name used to create a trigger."
-        Default: 'activity-detection-livestream-bucket'
-        
-    DetectionTableName: 
+        Default: "activity-detection-livestream-bucket"
+
+    DetectionTableName:
         Type: String
         Description: DynamoDB table to save prediction results
         Default: "activity-detection-table"
 
-    EndpointName: 
+    EndpointName:
         Type: String
         Description: SageMaker endpoint for model deployment
         Default: "activity-detection-endpoint"
 
-    ModelMaxFrames: 
+    ModelMaxFrames:
         Type: Number
         Description: Maximum number of frames used for activity detection model
         Default: 32
-        
+
 Resources:
     LivestreamLambdaFunction:
         Type: AWS::Lambda::Function
         Properties:
             FunctionName: !Ref LambdaName
-            Runtime: python3.6
+            Runtime: python3.9
             Role: !GetAtt LivestreamLambdaRole.Arn
-            Code: 
+            Code:
                 S3Bucket: !Ref LambdaCodeBucket
                 S3Key: "artifacts/amazon-sagemaker-activity-detection/deployment/lambda/lambda_function.zip"
             Handler: lambda_function.lambda_handler
@@ -57,41 +57,41 @@ Resources:
             Action: lambda:InvokeFunction
             FunctionName: !Ref LivestreamLambdaFunction
             Principal: s3.amazonaws.com
-            SourceArn: 
+            SourceArn:
                 Fn::Sub: "arn:aws:s3:::${TriggerBucketName}"
             SourceAccount: !Ref AWS::AccountId
-            
+
     LambdaTrigger:
-       Type: AWS::S3::Bucket
-       DependsOn: LivestreamLambdaPermission
-       Properties:
-           BucketName: !Ref TriggerBucketName
-           NotificationConfiguration:
-               LambdaConfigurations:
-                   - Event: s3:ObjectCreated:*
-                     Filter:
-                       S3Key:
-                           Rules:
-                               - Name: prefix
-                                 Value: "livestream_pipe/"
-                               - Name: suffix
-                                 Value: ".ts"
-                     Function: !GetAtt LivestreamLambdaFunction.Arn
-                     
-    LivestreamLambdaRole:
-        Type: 'AWS::IAM::Role'
+        Type: AWS::S3::Bucket
+        DependsOn: LivestreamLambdaPermission
         Properties:
-            RoleName: 'LivestreamLambdaRole'
+            BucketName: !Ref TriggerBucketName
+            NotificationConfiguration:
+                LambdaConfigurations:
+                    - Event: s3:ObjectCreated:*
+                      Filter:
+                          S3Key:
+                              Rules:
+                                  - Name: prefix
+                                    Value: "livestream_pipe/"
+                                  - Name: suffix
+                                    Value: ".ts"
+                      Function: !GetAtt LivestreamLambdaFunction.Arn
+
+    LivestreamLambdaRole:
+        Type: "AWS::IAM::Role"
+        Properties:
+            RoleName: "LivestreamLambdaRole"
             AssumeRolePolicyDocument:
                 Version: 2012-10-17
                 Statement:
-                  - Effect: Allow
-                    Principal:
-                      Service:
-                      - "lambda.amazonaws.com"
-                    Action:
-                      - 'sts:AssumeRole'
+                    - Effect: Allow
+                      Principal:
+                          Service:
+                              - "lambda.amazonaws.com"
+                      Action:
+                          - "sts:AssumeRole"
             ManagedPolicyArns:
-                - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
-                - 'arn:aws:iam::aws:policy/AmazonS3FullAccess'
-                - 'arn:aws:iam::aws:policy/AmazonSageMakerFullAccess'
+                - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+                - "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+                - "arn:aws:iam::aws:policy/AmazonSageMakerFullAccess"


### PR DESCRIPTION
This PR addresses an issue where the python3.6 runtime is no longer supported for creating or updating AWS Lambda functions. The error encountered is as follows:

```
Resource handler returned message: "The runtime parameter of python3.6 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (python3.9) while creating or updating functions. (Service: Lambda, Status Code: 400, Request ID: 9e7f3933-94a5-468f-849d-951ccacb7c27)" (RequestToken: ba154c34-211e-c84e-6339-e1df82da256c, HandlerErrorCode: InvalidRequest)
```
Changes made in this PR:

	1.	Updated the Lambda function runtime from python3.6 to python3.9 in the CloudFormation stack.

Please review the changes and test the stack to ensure there are no issues with the updated runtime. This update is necessary to maintain compatibility with AWS Lambda’s supported runtimes and avoid deployment errors.

Feel free to adjust the details to better fit your project’s specifics or any additional context you might want to provide.